### PR TITLE
Set up Windows workflow

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -28,7 +28,7 @@ jobs:
 
   # Hatch builds Linux wheels with a platform tag not permitted by PyPI. Hence,
   # use cibuildwheel.
-  build_linux:
+  build_ubuntu_windows:
     strategy:
       matrix:
         os: ['ubuntu-22.04', 'windows-2022']
@@ -45,7 +45,7 @@ jobs:
 
   release:
     if: github.ref_type == 'tag'
-    needs: [build_macos, build_linux]
+    needs: [build_macos, build_ubuntu_windows]
     runs-on: ubuntu-22.04
     permissions: write-all
     steps:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -26,12 +26,12 @@ jobs:
         name: wheel-${{ matrix.os }}-${{ matrix.python }}
         path: dist/*.whl
 
-  # Hatch builds wheels with a platform tag not permitted by PyPI. Hence, use
-  # cibuildwheel.
+  # Hatch builds Linux wheels with a platform tag not permitted by PyPI. Hence,
+  # use cibuildwheel.
   build_linux:
     strategy:
       matrix:
-        os: ['ubuntu-22.04']
+        os: ['ubuntu-22.04', 'windows-2022']
     name: build on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,6 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - run: pipx install hatch
-    - run: hatch -v run python -m unittest
+    - run: hatch run python -m unittest
       env:
         HATCH_PYTHON: ${{ steps.sp.outputs.python-path }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: ['macos-14', 'ubuntu-22.04', 'windows-2022']
+        os: ['macos-13', 'macos-14', 'ubuntu-22.04', 'windows-2022']
         python: ['3.10', '3.11', '3.12', '3.13']
     name: test on ${{ matrix.os }} with ${{ matrix.python }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: ['macos-14', 'ubuntu-22.04']
+        os: ['macos-14', 'ubuntu-22.04', 'windows-2022']
         python: ['3.10', '3.11', '3.12', '3.13']
     name: test on ${{ matrix.os }} with ${{ matrix.python }}
     runs-on: ${{ matrix.os }}
@@ -16,6 +16,6 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - run: pipx install hatch
-    - run: hatch run python -m unittest
+    - run: hatch -v run python -m unittest
       env:
         HATCH_PYTHON: ${{ steps.sp.outputs.python-path }}

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,12 @@
+import platform
+
 import setuptools
 
 setuptools.setup(
     ext_modules=[
         setuptools.Extension(
             name="pysorteddict",
-            extra_compile_args=["-std=c++20"],
+            extra_compile_args=["/std:c++14" if platform.system() == "Windows" else "-std=c++14"],
             sources=["src/pysorteddict/pysorteddict.cc"],
             py_limited_api=True,
         )

--- a/src/pysorteddict/pysorteddict.cc
+++ b/src/pysorteddict/pysorteddict.cc
@@ -75,9 +75,13 @@ static PyObject* sorted_dict_type_new(PyTypeObject* type, PyObject* args, PyObje
     }
 
     SortedDictType* sd = (SortedDictType*)self;
-    // Casting a string constant to a non-const pointer is not permitted in
-    // C++, but the signature of this function is such that I am forced to.
-    char* args_names[] = { "key_type", nullptr };
+    // Up to Python 3.12, the argument parser below took an array of pointers
+    // (with each pointer pointing to a C string) as its fourth argument.
+    // However, C++ does not allow converting a string constant to a pointer.
+    // Hence, I use a character array to construct the C string, and then place
+    // it in an array of pointers.
+    char key_type[] = "key_type";
+    char* args_names[] = { key_type, nullptr };
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|", args_names, &sd->key_type))
     {
         Py_DECREF(self);


### PR DESCRIPTION
Closes #9. The first part of the problem (removing designated initialisers) was handled in #10. The second part (constructing a non-`const` C string) is handled in 92844d842fafb9c5b6f5fe7c5c11221b40264da7 in this pull request.