### PR TITLE
Implement `items`, `keys` and `values`; mark as `dict` subclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,23 +26,34 @@ command.
 
 ## Usage
 
-All keys in a sorted dictionary must be of the same type, which must be passed to the constructor. The values, though,
-can be of any type.
+All keys in a sorted dictionary must be of the same type, which is determined when the first key-value pair is inserted
+into it. The values, though, can be of any type.
 
 ```python
+import json
+
 from pysorteddict import SortedDict
 
-sorted_dict = SortedDict(int)
-sorted_dict[5659] = "gaining weight is"
-sorted_dict[1992] = 31.692
-sorted_dict[24274] = "times easier than"
-sorted_dict[9765] = ["losing", "weight"]
-print(sorted_dict)
+sorted_dict = SortedDict()
+sorted_dict["honestly"] = "weight"
+sorted_dict["gain is"] = 31.692
+sorted_dict["times"] = "easier than"
+sorted_dict["losing"] = ["weight"]
+print(json.dumps(sorted_dict, indent=2, sort_keys=False))
 ```
 
-This program should output
-`{1992: 31.692, 5659: 'gaining weight is', 9765: ['losing', 'weight'], 24274: 'times easier than'}`. Note that the keys
-are in ascending order.
+When run, this program will output the keys in ascending order.
+
+```json
+{
+  "gain is": 31.692,
+  "honestly": "weight",
+  "losing": [
+    "weight"
+  ],
+  "times": "easier than"
+}
+```
 
 ## Implementation Details
 

--- a/README.md
+++ b/README.md
@@ -64,12 +64,15 @@ pysorteddict is implemented entirely in C++. `SortedDict` provides a Python inte
 
 ### Constructor
 
-#### `SortedDict(key_type: type) -> SortedDict`
+#### `SortedDict(*args, **kwargs) -> SortedDict`
 
-Create a new sorted dictionary in which the keys are of type `key_type`. As of the current version, `key_type` must be
-`int`. Support for some more types will be added in due course.
+Create an empty sorted dictionary. `args` and `kwargs` are ignored.
 
 ### Magic Methods
+
+#### `repr(d)`
+
+Return a human-readable representation of the sorted dictionary `d`.
 
 #### `key in d`
 
@@ -83,25 +86,25 @@ Return the number of key-value pairs in the sorted dictionary `d`.
 
 Return the value mapped to `key` in the sorted dictionary `d`.
 
-* If `type(key)` is not the same as `key_type` passed to the constructor, raise `TypeError`.
+* If no key-value pairs have been inserted into `d` yet, raise `ValueError`.
+* If `type(key)` does not match the type of the first key inserted into `d`, raise `TypeError`.
 * If `key` is not present in `d`, raise `KeyError`.
 
 #### `d[key] = value`
 
 Map `value` to `key` in the sorted dictionary `d`, replacing the previously-mapped value (if any).
 
-* If `type(key)` is not the same as `key_type` passed to the constructor, raise `TypeError`.
+* If no key-value pairs have been inserted into `d` yet and `type(key)` isn't one of the supported types (`bytes`,
+  `int` and `str`), raise `TypeError`.
+* If `type(key)` does not match the type of the first key inserted into `d`, raise `TypeError`.
 
 #### `del d[key]`
 
 Remove `key` and the value mapped to it from the sorted dictionary `d`.
 
-* If `type(key)` is not the same as `key_type` passed to the constructor, raise `TypeError`.
+* If no key-value pairs have been inserted into `d` yet, raise `ValueError`.
+* If `type(key)` does not match the type of the first key inserted into `d`, raise `TypeError`.
 * If `key` is not present in `d`, raise `KeyError`.
-
-#### `str(d)`
-
-Return a human-readable representation of the sorted dictionary `d`.
 
 ### Other Methods
 
@@ -111,17 +114,19 @@ Remove all key-value pairs in the sorted dictionary `d`.
 
 #### `d.copy() -> SortedDict`
 
-Return a shallow copy of the sorted dictionary ``d``.
+Return a shallow copy of the sorted dictionary `d`.
 
 #### `d.items() -> list[tuple[object, object]]`
 
-Create and return a new list containing the key-value pairs in the sorted dictionary ``d``. This list will be sorted.
+Return the key-value pairs in the sorted dictionary `d`. The list will be sorted. It will exist independently of `d`;
+it won't be a view on its items.
 
 #### `d.keys() -> list[object]`
 
-Create and return a new list containing the keys in the sorted dictionary ``d``. This list will be sorted.
+Return the keys in the sorted dictionary `d`. The list will be sorted. It will exist independently of ``d``; it won't
+be a view on its keys.
 
 #### `d.values() -> list[object]`
 
-Create and return a new list containing the values in the sorted dictionary ``d``. This list will be sorted by the keys
-which the values are mapped to.
+Return the values in the sorted dictionary `d`. The list will be sorted by the keys the values are mapped to. It will
+exist independently of `d`; it won't be a view on its values.

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -1,13 +1,12 @@
 #! /usr/bin/env python3
 
+import json
+
 from pysorteddict import SortedDict
 
-sd = SortedDict(int)
-
-sd[100] = "wut"
-sd[1] = "ok"
-sd[1] = "notok"
-print(sd, len(sd))
-print(sd[1])
-print(sd.keys(), sd.values(), sd.items())
-del sd
+sorted_dict = SortedDict(int)
+sorted_dict[5659] = "gaining weight is"
+sorted_dict[1992] = 31.692
+sorted_dict[24274] = "times easier than"
+sorted_dict[9765] = ["losing", "weight"]
+print(json.dumps(sorted_dict, indent=2))

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -4,9 +4,9 @@ import json
 
 from pysorteddict import SortedDict
 
-sorted_dict = SortedDict(int)
-sorted_dict[5659] = "gaining weight is"
-sorted_dict[1992] = 31.692
-sorted_dict[24274] = "times easier than"
-sorted_dict[9765] = ["losing", "weight"]
-print(json.dumps(sorted_dict, indent=2))
+sorted_dict = SortedDict()
+sorted_dict["honestly"] = "weight"
+sorted_dict["gain is"] = 31.692
+sorted_dict["times"] = "easier than"
+sorted_dict["losing"] = ["weight"]
+print(json.dumps(sorted_dict, indent=2, sort_keys=False))

--- a/src/pysorteddict/pysorteddict.cc
+++ b/src/pysorteddict/pysorteddict.cc
@@ -451,11 +451,12 @@ static PyObject* sorted_dict_type_copy(PyObject* self, PyObject* args)
     return sd->copy();
 }
 
-static PyObject*sorted_dict_type_items(PyObject*self, PyObject*args){
-    PyObject *t = PyTuple_New(2);
+static PyObject* sorted_dict_type_items(PyObject* self, PyObject* args)
+{
+    PyObject* t = PyTuple_New(2);
     PyTuple_SET_ITEM(t, 0, Py_None);
     PyTuple_SET_ITEM(t, 1, Py_None);
-    PyObject *l = PyList_New(1);
+    PyObject* l = PyList_New(1);
     PyList_SET_ITEM(l, 0, t);
     return l;
 }
@@ -510,52 +511,52 @@ PyDoc_STRVAR(
 
 // clang-format off
 static PyTypeObject sorted_dict_type = {
-    PyVarObject_HEAD_INIT(&PyType_Type, 0)  // ob_base
-    "SortedDict",                           // tp_name
-    sizeof(SortedDictType),                 // tp_basicsize
-    0,                                      // tp_itemsize
-    sorted_dict_type_dealloc,               // tp_dealloc
-    0,                                      // tp_vectorcall_offset
-    nullptr,                                // tp_getattr
-    nullptr,                                // tp_setattr
-    nullptr,                                // tp_as_async
-    sorted_dict_type_repr,                  // tp_repr
-    nullptr,                                // tp_as_number
-    &sorted_dict_type_sequence,             // tp_as_sequence
-    &sorted_dict_type_mapping,              // tp_as_mapping
-    PyObject_HashNotImplemented,            // tp_hash
-    nullptr,                                // tp_call
-    nullptr,                                // tp_str
-    nullptr,                                // tp_getattro
-    nullptr,                                // tp_setattro
-    nullptr,                                // tp_as_buffer
-    Py_TPFLAGS_DICT_SUBCLASS,                     // tp_flags
-    sorted_dict_type_doc,                   // tp_doc
-    nullptr,                                // tp_traverse
-    nullptr,                                // tp_clear
-    nullptr,                                // tp_richcompare
-    0,                                      // tp_weaklistoffset
-    nullptr,                                // tp_iter
-    nullptr,                                // tp_iternext
-    sorted_dict_type_methods,               // tp_methods
-    nullptr,                                // tp_members
-    nullptr,                                // tp_getset
-    nullptr,                                // tp_base
-    nullptr,                                // tp_dict
-    nullptr,                                // tp_descr_get
-    nullptr,                                // tp_descr_set
-    0,                                      // tp_dictoffset
-    sorted_dict_type_init,                  // tp_init
-    PyType_GenericAlloc,                    // tp_alloc
-    sorted_dict_type_new,                   // tp_new
-    PyObject_Free,                          // tp_free
-    nullptr,                                // tp_is_gc
-    nullptr,                                // tp_bases
-    nullptr,                                // tp_mro
-    nullptr,                                // tp_cache
-    nullptr,                                // tp_subclasses
-    nullptr,                                // tp_weaklist
-    nullptr,                                // tp_del
+    PyVarObject_HEAD_INIT(&PyType_Type, 0)        // ob_base
+    "SortedDict",                                 // tp_name
+    sizeof(SortedDictType),                       // tp_basicsize
+    0,                                            // tp_itemsize
+    sorted_dict_type_dealloc,                     // tp_dealloc
+    0,                                            // tp_vectorcall_offset
+    nullptr,                                      // tp_getattr
+    nullptr,                                      // tp_setattr
+    nullptr,                                      // tp_as_async
+    sorted_dict_type_repr,                        // tp_repr
+    nullptr,                                      // tp_as_number
+    &sorted_dict_type_sequence,                   // tp_as_sequence
+    &sorted_dict_type_mapping,                    // tp_as_mapping
+    PyObject_HashNotImplemented,                  // tp_hash
+    nullptr,                                      // tp_call
+    nullptr,                                      // tp_str
+    nullptr,                                      // tp_getattro
+    nullptr,                                      // tp_setattro
+    nullptr,                                      // tp_as_buffer
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_DICT_SUBCLASS,  // tp_flags
+    sorted_dict_type_doc,                         // tp_doc
+    nullptr,                                      // tp_traverse
+    nullptr,                                      // tp_clear
+    nullptr,                                      // tp_richcompare
+    0,                                            // tp_weaklistoffset
+    nullptr,                                      // tp_iter
+    nullptr,                                      // tp_iternext
+    sorted_dict_type_methods,                     // tp_methods
+    nullptr,                                      // tp_members
+    nullptr,                                      // tp_getset
+    nullptr,                                      // tp_base
+    nullptr,                                      // tp_dict
+    nullptr,                                      // tp_descr_get
+    nullptr,                                      // tp_descr_set
+    0,                                            // tp_dictoffset
+    sorted_dict_type_init,                        // tp_init
+    PyType_GenericAlloc,                          // tp_alloc
+    sorted_dict_type_new,                         // tp_new
+    PyObject_Free,                                // tp_free
+    nullptr,                                      // tp_is_gc
+    nullptr,                                      // tp_bases
+    nullptr,                                      // tp_mro
+    nullptr,                                      // tp_cache
+    nullptr,                                      // tp_subclasses
+    nullptr,                                      // tp_weaklist
+    nullptr,                                      // tp_del
 };
 // clang-format on
 

--- a/src/pysorteddict/pysorteddict.cc
+++ b/src/pysorteddict/pysorteddict.cc
@@ -500,12 +500,6 @@ static PyObject* sorted_dict_type_clear(PyObject* self, PyObject* args)
 }
 
 PyDoc_STRVAR(
-    sorted_dict_type_copy_doc,
-    "d.copy() -> SortedDict\n"
-    "Return a shallow copy of the sorted dictionary ``d``."
-);
-
-PyDoc_STRVAR(
     sorted_dict_type_items_doc,
     "d.items() -> list[tuple[object, object]]\n"
     "Return the key-value pairs in the sorted dictionary ``d``. The list will be sorted. "
@@ -543,6 +537,12 @@ static PyObject* sorted_dict_type_values(PyObject* self, PyObject* args)
     SortedDictType* sd = reinterpret_cast<SortedDictType*>(self);
     return sd->values();
 }
+
+PyDoc_STRVAR(
+    sorted_dict_type_copy_doc,
+    "d.copy() -> SortedDict\n"
+    "Return a shallow copy of the sorted dictionary ``d``."
+);
 
 static PyObject* sorted_dict_type_copy(PyObject* self, PyObject* args)
 {

--- a/src/pysorteddict/pysorteddict.cc
+++ b/src/pysorteddict/pysorteddict.cc
@@ -500,10 +500,22 @@ static PyObject* sorted_dict_type_clear(PyObject* self, PyObject* args)
 }
 
 PyDoc_STRVAR(
+    sorted_dict_type_copy_doc,
+    "d.copy() -> SortedDict\n"
+    "Return a shallow copy of the sorted dictionary ``d``."
+);
+
+static PyObject* sorted_dict_type_copy(PyObject* self, PyObject* args)
+{
+    SortedDictType* sd = reinterpret_cast<SortedDictType*>(self);
+    return sd->copy();
+}
+
+PyDoc_STRVAR(
     sorted_dict_type_items_doc,
     "d.items() -> list[tuple[object, object]]\n"
     "Return the key-value pairs in the sorted dictionary ``d``. The list will be sorted. "
-    "It will exist independently of ``d``; it won't be a view on the items of ``d``."
+    "It will exist independently of ``d``; it won't be a view on its items."
 );
 
 static PyObject* sorted_dict_type_items(PyObject* self, PyObject* args)
@@ -516,7 +528,7 @@ PyDoc_STRVAR(
     sorted_dict_type_keys_doc,
     "d.keys() -> list[object]\n"
     "Return the keys in the sorted dictionary ``d``. The list will be sorted. "
-    "It will exist independently of ``d``; it won't be a view on the keys of ``d``."
+    "It will exist independently of ``d``; it won't be a view on its keys."
 );
 
 static PyObject* sorted_dict_type_keys(PyObject* self, PyObject* args)
@@ -529,25 +541,13 @@ PyDoc_STRVAR(
     sorted_dict_type_values_doc,
     "d.values() -> list[object]\n"
     "Return the values in the sorted dictionary ``d``. The list will be sorted by the keys the values are mapped to. "
-    "It will exist independently of ``d``; it won't be a view on the values of ``d``."
+    "It will exist independently of ``d``; it won't be a view on its values."
 );
 
 static PyObject* sorted_dict_type_values(PyObject* self, PyObject* args)
 {
     SortedDictType* sd = reinterpret_cast<SortedDictType*>(self);
     return sd->values();
-}
-
-PyDoc_STRVAR(
-    sorted_dict_type_copy_doc,
-    "d.copy() -> SortedDict\n"
-    "Return a shallow copy of the sorted dictionary ``d``."
-);
-
-static PyObject* sorted_dict_type_copy(PyObject* self, PyObject* args)
-{
-    SortedDictType* sd = reinterpret_cast<SortedDictType*>(self);
-    return sd->copy();
 }
 
 // clang-format off
@@ -608,7 +608,7 @@ static PyObject* sorted_dict_type_new(PyTypeObject* type, PyObject* args, PyObje
 PyDoc_STRVAR(
     sorted_dict_type_doc,
     "SortedDict(*args, **kwargs) -> SortedDict\n"
-    "Create an empty sorted dictionary."
+    "Create an empty sorted dictionary. `args` and `kwargs` are ignored."
 );
 
 // clang-format off

--- a/src/pysorteddict/pysorteddict.cc
+++ b/src/pysorteddict/pysorteddict.cc
@@ -614,7 +614,7 @@ PyDoc_STRVAR(
 // clang-format off
 static PyTypeObject sorted_dict_type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)          // ob_base
-    "SortedDict",                                   // tp_name
+    "pysorteddict.SortedDict",                      // tp_name
     sizeof(SortedDictType),                         // tp_basicsize
     0,                                              // tp_itemsize
     sorted_dict_type_dealloc,                       // tp_dealloc

--- a/src/pysorteddict/pysorteddict.cc
+++ b/src/pysorteddict/pysorteddict.cc
@@ -333,10 +333,8 @@ PyObject* SortedDictType::items(void)
             Py_DECREF(sd_items);
             return nullptr;
         }
-        PyTuple_SET_ITEM(sd_item, 0, item.first);
-        Py_INCREF(item.first);
-        PyTuple_SET_ITEM(sd_item, 1, item.second);
-        Py_INCREF(item.second);
+        PyTuple_SET_ITEM(sd_item, 0, Py_NewRef(item.first));
+        PyTuple_SET_ITEM(sd_item, 1, Py_NewRef(item.second));
         PyList_SET_ITEM(sd_items, idx++, sd_item);
     }
     return sd_items;
@@ -352,8 +350,7 @@ PyObject* SortedDictType::keys(void)
     Py_ssize_t idx = 0;
     for (auto& item : *this->map)
     {
-        PyList_SET_ITEM(sd_keys, idx++, item.first);
-        Py_INCREF(item.first);
+        PyList_SET_ITEM(sd_keys, idx++, Py_NewRef(item.first));
     }
     return sd_keys;
 }
@@ -368,8 +365,7 @@ PyObject* SortedDictType::values(void)
     Py_ssize_t idx = 0;
     for (auto& item : *this->map)
     {
-        PyList_SET_ITEM(sd_values, idx++, item.second);
-        Py_INCREF(item.second);
+        PyList_SET_ITEM(sd_values, idx++, Py_NewRef(item.second));
     }
     return sd_values;
 }

--- a/src/pysorteddict/pysorteddict.cc
+++ b/src/pysorteddict/pysorteddict.cc
@@ -508,7 +508,7 @@ PyDoc_STRVAR(
 PyDoc_STRVAR(
     sorted_dict_type_items_doc,
     "d.items() -> list[tuple[object, object]]\n"
-    "Return a list containing the key-value pairs in the sorted dictionary ``d``. This list will be sorted. "
+    "Return the key-value pairs in the sorted dictionary ``d``. The list will be sorted. "
     "It exists independently of ``d``; it is not a view on the items of ``d``."
 );
 
@@ -521,7 +521,7 @@ static PyObject* sorted_dict_type_items(PyObject* self, PyObject* args)
 PyDoc_STRVAR(
     sorted_dict_type_keys_doc,
     "d.keys() -> list[object]\n"
-    "Return a list containing the keys in the sorted dictionary ``d``. This list will be sorted. "
+    "Return the keys in the sorted dictionary ``d``. The list will be sorted. "
     "It exists independently of ``d``; it is not a view on the keys of ``d``."
 );
 
@@ -534,7 +534,7 @@ static PyObject* sorted_dict_type_keys(PyObject* self, PyObject* args)
 PyDoc_STRVAR(
     sorted_dict_type_values_doc,
     "d.values() -> list[object]\n"
-    "Return a list containing the values in the sorted dictionary ``d``. This list will be sorted by the mapped keys. "
+    "Return the values in the sorted dictionary ``d``. The list will be sorted by the keys the values are mapped to. "
     "It exists independently of ``d``; it is not a view on the values of ``d``."
 );
 

--- a/src/pysorteddict/pysorteddict.cc
+++ b/src/pysorteddict/pysorteddict.cc
@@ -509,7 +509,7 @@ PyDoc_STRVAR(
     sorted_dict_type_items_doc,
     "d.items() -> list[tuple[object, object]]\n"
     "Return the key-value pairs in the sorted dictionary ``d``. The list will be sorted. "
-    "It exists independently of ``d``; it is not a view on the items of ``d``."
+    "It will exist independently of ``d``; it won't be a view on the items of ``d``."
 );
 
 static PyObject* sorted_dict_type_items(PyObject* self, PyObject* args)
@@ -522,7 +522,7 @@ PyDoc_STRVAR(
     sorted_dict_type_keys_doc,
     "d.keys() -> list[object]\n"
     "Return the keys in the sorted dictionary ``d``. The list will be sorted. "
-    "It exists independently of ``d``; it is not a view on the keys of ``d``."
+    "It will exist independently of ``d``; it won't be a view on the keys of ``d``."
 );
 
 static PyObject* sorted_dict_type_keys(PyObject* self, PyObject* args)
@@ -535,7 +535,7 @@ PyDoc_STRVAR(
     sorted_dict_type_values_doc,
     "d.values() -> list[object]\n"
     "Return the values in the sorted dictionary ``d``. The list will be sorted by the keys the values are mapped to. "
-    "It exists independently of ``d``; it is not a view on the values of ``d``."
+    "It will exist independently of ``d``; it won't be a view on the values of ``d``."
 );
 
 static PyObject* sorted_dict_type_values(PyObject* self, PyObject* args)

--- a/src/pysorteddict/pysorteddict.cc
+++ b/src/pysorteddict/pysorteddict.cc
@@ -511,52 +511,52 @@ PyDoc_STRVAR(
 
 // clang-format off
 static PyTypeObject sorted_dict_type = {
-    PyVarObject_HEAD_INIT(&PyType_Type, 0)        // ob_base
-    "SortedDict",                                 // tp_name
-    sizeof(SortedDictType),                       // tp_basicsize
-    0,                                            // tp_itemsize
-    sorted_dict_type_dealloc,                     // tp_dealloc
-    0,                                            // tp_vectorcall_offset
-    nullptr,                                      // tp_getattr
-    nullptr,                                      // tp_setattr
-    nullptr,                                      // tp_as_async
-    sorted_dict_type_repr,                        // tp_repr
-    nullptr,                                      // tp_as_number
-    &sorted_dict_type_sequence,                   // tp_as_sequence
-    &sorted_dict_type_mapping,                    // tp_as_mapping
-    PyObject_HashNotImplemented,                  // tp_hash
-    nullptr,                                      // tp_call
-    nullptr,                                      // tp_str
-    nullptr,                                      // tp_getattro
-    nullptr,                                      // tp_setattro
-    nullptr,                                      // tp_as_buffer
-    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_DICT_SUBCLASS,  // tp_flags
-    sorted_dict_type_doc,                         // tp_doc
-    nullptr,                                      // tp_traverse
-    nullptr,                                      // tp_clear
-    nullptr,                                      // tp_richcompare
-    0,                                            // tp_weaklistoffset
-    nullptr,                                      // tp_iter
-    nullptr,                                      // tp_iternext
-    sorted_dict_type_methods,                     // tp_methods
-    nullptr,                                      // tp_members
-    nullptr,                                      // tp_getset
-    nullptr,                                      // tp_base
-    nullptr,                                      // tp_dict
-    nullptr,                                      // tp_descr_get
-    nullptr,                                      // tp_descr_set
-    0,                                            // tp_dictoffset
-    sorted_dict_type_init,                        // tp_init
-    PyType_GenericAlloc,                          // tp_alloc
-    sorted_dict_type_new,                         // tp_new
-    PyObject_Free,                                // tp_free
-    nullptr,                                      // tp_is_gc
-    nullptr,                                      // tp_bases
-    nullptr,                                      // tp_mro
-    nullptr,                                      // tp_cache
-    nullptr,                                      // tp_subclasses
-    nullptr,                                      // tp_weaklist
-    nullptr,                                      // tp_del
+    PyVarObject_HEAD_INIT(&PyType_Type, 0)          // ob_base
+    "SortedDict",                                   // tp_name
+    sizeof(SortedDictType),                         // tp_basicsize
+    0,                                              // tp_itemsize
+    sorted_dict_type_dealloc,                       // tp_dealloc
+    0,                                              // tp_vectorcall_offset
+    nullptr,                                        // tp_getattr
+    nullptr,                                        // tp_setattr
+    nullptr,                                        // tp_as_async
+    sorted_dict_type_repr,                          // tp_repr
+    nullptr,                                        // tp_as_number
+    &sorted_dict_type_sequence,                     // tp_as_sequence
+    &sorted_dict_type_mapping,                      // tp_as_mapping
+    PyObject_HashNotImplemented,                    // tp_hash
+    nullptr,                                        // tp_call
+    nullptr,                                        // tp_str
+    nullptr,                                        // tp_getattro
+    nullptr,                                        // tp_setattro
+    nullptr,                                        // tp_as_buffer
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DICT_SUBCLASS,  // tp_flags
+    sorted_dict_type_doc,                           // tp_doc
+    nullptr,                                        // tp_traverse
+    nullptr,                                        // tp_clear
+    nullptr,                                        // tp_richcompare
+    0,                                              // tp_weaklistoffset
+    nullptr,                                        // tp_iter
+    nullptr,                                        // tp_iternext
+    sorted_dict_type_methods,                       // tp_methods
+    nullptr,                                        // tp_members
+    nullptr,                                        // tp_getset
+    nullptr,                                        // tp_base
+    nullptr,                                        // tp_dict
+    nullptr,                                        // tp_descr_get
+    nullptr,                                        // tp_descr_set
+    0,                                              // tp_dictoffset
+    sorted_dict_type_init,                          // tp_init
+    PyType_GenericAlloc,                            // tp_alloc
+    sorted_dict_type_new,                           // tp_new
+    PyObject_Free,                                  // tp_free
+    nullptr,                                        // tp_is_gc
+    nullptr,                                        // tp_bases
+    nullptr,                                        // tp_mro
+    nullptr,                                        // tp_cache
+    nullptr,                                        // tp_subclasses
+    nullptr,                                        // tp_weaklist
+    nullptr,                                        // tp_del
 };
 // clang-format on
 

--- a/src/pysorteddict/pysorteddict.cc
+++ b/src/pysorteddict/pysorteddict.cc
@@ -451,6 +451,15 @@ static PyObject* sorted_dict_type_copy(PyObject* self, PyObject* args)
     return sd->copy();
 }
 
+static PyObject*sorted_dict_type_items(PyObject*self, PyObject*args){
+    PyObject *t = PyTuple_New(2);
+    PyTuple_SET_ITEM(t, 0, Py_None);
+    PyTuple_SET_ITEM(t, 1, Py_None);
+    PyObject *l = PyList_New(1);
+    PyList_SET_ITEM(l, 0, t);
+    return l;
+}
+
 // clang-format off
 static PyMethodDef sorted_dict_type_methods[] = {
     {
@@ -464,6 +473,11 @@ static PyMethodDef sorted_dict_type_methods[] = {
         sorted_dict_type_copy,        // ml_meth
         METH_NOARGS,                  // ml_flags
         sorted_dict_type_copy_doc,    // ml_doc
+    },
+    {
+        "items",                       // ml_name
+        sorted_dict_type_items,        // ml_meth
+        METH_NOARGS,                  // ml_flags
     },
     {
         nullptr,
@@ -515,7 +529,7 @@ static PyTypeObject sorted_dict_type = {
     nullptr,                                // tp_getattro
     nullptr,                                // tp_setattro
     nullptr,                                // tp_as_buffer
-    Py_TPFLAGS_DEFAULT,                     // tp_flags
+    Py_TPFLAGS_DICT_SUBCLASS,                     // tp_flags
     sorted_dict_type_doc,                   // tp_doc
     nullptr,                                // tp_traverse
     nullptr,                                // tp_clear

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -107,7 +107,10 @@ def sorted_dict(request, resources):
 
     # Tearing down: verify some non-mutating methods.
     assert len(sorted_dict) == len(resources.normal_dict)
-    assert str(sorted_dict) == f"SortedDict({dict(sorted(resources.normal_dict.items()))})"
+    assert sorted_dict.items() == sorted(resources.normal_dict.items())
+    assert sorted_dict.keys() == sorted(resources.normal_dict)
+    assert sorted_dict.values() == [item[1] for item in sorted(resources.normal_dict.items())]
+    assert repr(sorted_dict) == f"SortedDict({dict(sorted(resources.normal_dict.items()))})"
 
 
 # Run each test with each key type, and on the sorted dictionary and its copy.


### PR DESCRIPTION
May have been a bit too hasty when I removed those three methods.😅