### PR TITLE
Refactor key type and key check

### DIFF
--- a/src/pysorteddict/pysorteddict.cc
+++ b/src/pysorteddict/pysorteddict.cc
@@ -177,7 +177,8 @@ PyObject* SortedDictType::repr(void)
  */
 int SortedDictType::contains(PyObject* key)
 {
-    if (!this->are_key_type_and_key_valid(key, false) || this->map->find(key) == this->map->end())
+    if (this->key_type == nullptr || Py_IS_TYPE(key, reinterpret_cast<PyTypeObject*>(this->key_type)) == 0
+        || this->map->find(key) == this->map->end())
     {
         return 0;
     }

--- a/src/pysorteddict/pysorteddict.cc
+++ b/src/pysorteddict/pysorteddict.cc
@@ -122,7 +122,7 @@ bool SortedDictType::are_key_type_and_key_value_pair_okay(PyObject* key, PyObjec
             return false;
         }
     }
-    return key_already_checked || Py_IS_TYPE(key, this->key_type) != 0;
+    return key_already_checked || Py_IS_TYPE(key, reinterpret_cast<PyTypeObject*>(this->key_type)) != 0;
 }
 
 PyObject* SortedDictType::repr(void)

--- a/src/pysorteddict/pysorteddict.cc
+++ b/src/pysorteddict/pysorteddict.cc
@@ -45,7 +45,6 @@ struct SortedDictType
 public:
     PyObject_HEAD;
 
-private:
     // Pointer to an object on the heap. Can't be the object itself, because
     // this container will be allocated a definite amount of space, which won't
     // allow the object to grow.

--- a/src/pysorteddict/pysorteddict.cc
+++ b/src/pysorteddict/pysorteddict.cc
@@ -42,8 +42,10 @@ struct PyObject_CustomCompare
 
 struct SortedDictType
 {
+public:
     PyObject_HEAD;
 
+private:
     // Pointer to an object on the heap. Can't be the object itself, because
     // this container will be allocated a definite amount of space, which won't
     // allow the object to grow.
@@ -52,8 +54,11 @@ struct SortedDictType
     // The type of each key.
     PyObject* key_type;
 
-    void deinit(void);
+private:
     bool are_key_type_and_key_value_pair_okay(PyObject*, PyObject*);
+
+public:
+    void deinit(void);
     PyObject* repr(void);
     int contains(PyObject*);
     PyObject* getitem(PyObject*);

--- a/src/pysorteddict/pysorteddict.cc
+++ b/src/pysorteddict/pysorteddict.cc
@@ -82,6 +82,7 @@ void SortedDictType::deinit(void)
  * Check whether the key type of this sorted dictionary is set and whether the
  * given key-value pair can be inserted into this sorted dictionary. If the
  * value is not supplied, check whether it is valid to get or delete the key.
+ * On failure, set a Python exception.
  *
  * @param key Key.
  * @param value Value.


### PR DESCRIPTION
To avoid wasted computations, I should separate the exception-raising check and exception-safe check. This will make it easier to handle keys which are of the correct type but still not valid, such as NaN.