### PR TITLE
Use newer Setuptools on Windows to allow developing on MSYS2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,14 @@
 [build-system]
 # The Apple linker does not recognise `-Bsymbolic-functions`, one of the
-# arguments passed to it on macOS when building wheels for PyPy. Using an older
-# version of setuptools fixes this problem.
-requires = ["setuptools==70.0.0"]
+# arguments cibuildwheel passes to it on macOS when building wheels for PyPy.
+# Using an older version of setuptools fixes this problem. However, that
+# version does not recognise the MSYS2 platform tag, and aborts the build,
+# preventing me from developing on MSYS2. It is not possible to detect MSYS2
+# from here, so just test for Windows.
+requires = [
+    "setuptools==70.0.0; platform_system != 'Windows'",
+    "setuptools==71.0.0; platform_system == 'Windows'",
+]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 # The Apple linker does not recognise `-Bsymbolic-functions`, one of the
 # arguments cibuildwheel passes to it on macOS when building wheels for PyPy.
-# Using an older version of setuptools fixes this problem. However, that
+# Using an older version of Setuptools fixes this problem. However, that
 # version does not recognise the MSYS2 platform tag, and aborts the build,
 # preventing me from developing on MSYS2. It is not possible to detect MSYS2
 # from here, so just test for Windows.


### PR DESCRIPTION
MSYS2 provides a patched version of Python, which has a non-standard platform tag. The version of Setuptools which plays nice with the Apple Linker when cibuildwheel builds PyPy wheels is 70.0.0. This version rejects the non-standard platform tag, but version 71.0.0 allows it. Hence, use the latter version when building on Windows.

This change purely aids development on MSYS2. MSYS2 wheels won't be uploaded to PyPI. (Said wheels will actually be rejected because of the platform tag.)