### PR TITLE
Check for bad keys in separate method

### DIFF
--- a/src/pysorteddict/sorted_dict_type.cc
+++ b/src/pysorteddict/sorted_dict_type.cc
@@ -39,6 +39,21 @@ void SortedDictType::deinit(void)
 }
 
 /**
+ * Check whether the given key is comparable. For instance, NaN is not good
+ * because it cannot be compared with other floating-point numbers.
+ *
+ * The caller should ensure that the key type is set and that it matches the
+ * type of the given key prior to calling this method.
+ *
+ * @param key Key.
+ *
+ * @return `true` if the check succeeds, else `false`.
+ */
+bool SortedDictType::is_key_good(PyObject* key){
+    return this->key_type == &PyFloat_Type && std::isnan(PyFloat_AS_DOUBLE(key));
+}
+
+/**
  * Check whether the key type of this sorted dictionary is set and whether the
  * given key-value pair can be inserted into this sorted dictionary. If the
  * value is not supplied, check whether it is valid to get or delete the key.
@@ -87,16 +102,16 @@ bool SortedDictType::are_key_type_and_key_value_pair_okay(PyObject* key, PyObjec
         }
     }
 
-    // At this point, the key type (member) is guaranteed to be non-null.
+    // At this point, the key type is guaranteed to be non-null.
     if (!key_type_set_here && Py_IS_TYPE(key, this->key_type) == 0)
     {
         PyErr_Format(PyExc_TypeError, "wrong key type: want %R, got %R", this->key_type, Py_TYPE(key));
         return false;
     }
 
-    // At this point, the key (argument) is guaranteed to be of the correct
-    // type.
-    if (this->key_type == &PyFloat_Type && std::isnan(PyFloat_AS_DOUBLE(key)))
+    // At this point, the key is guaranteed to be of the correct type. Hence,
+    // it is safe to call this method.
+    if(!this->is_key_good(key)){
     {
         PyErr_Format(PyExc_ValueError, "bad key: %R", key);
         if (key_type_set_here)

--- a/src/pysorteddict/sorted_dict_type.cc
+++ b/src/pysorteddict/sorted_dict_type.cc
@@ -51,7 +51,10 @@ void SortedDictType::deinit(void)
  * @return `true` if the check succeeds, else `false`.
  */
 bool SortedDictType::is_key_good(PyObject* key){
-    return this->key_type == &PyFloat_Type && std::isnan(PyFloat_AS_DOUBLE(key));
+    if(this->key_type == &PyFloat_Type && std::isnan(PyFloat_AS_DOUBLE(key))){
+        return false;
+    }
+    return true;
 }
 
 /**

--- a/src/pysorteddict/sorted_dict_type.cc
+++ b/src/pysorteddict/sorted_dict_type.cc
@@ -40,8 +40,8 @@ void SortedDictType::deinit(void)
 
 /**
  * Check whether the given key can be inserted into this sorted dictionary. For
- * instance, NaN cannot be compared with other floating-point numbers, making
- * it unsuitable for insertion.
+ * instance, NaN cannot be compared with other floating-point numbers, so it
+ * cannot be inserted.
  *
  * The caller should ensure that the key type is set and that it matches the
  * type of the given key prior to calling this method.

--- a/src/pysorteddict/sorted_dict_type.cc
+++ b/src/pysorteddict/sorted_dict_type.cc
@@ -39,8 +39,9 @@ void SortedDictType::deinit(void)
 }
 
 /**
- * Check whether the given key is comparable. For instance, NaN is not good
- * because it cannot be compared with other floating-point numbers.
+ * Check whether the given key can be inserted into this sorted dictionary. For
+ * instance, NaN cannot be compared with other floating-point numbers, making
+ * it an unsuitable key.
  *
  * The caller should ensure that the key type is set and that it matches the
  * type of the given key prior to calling this method.

--- a/src/pysorteddict/sorted_dict_type.cc
+++ b/src/pysorteddict/sorted_dict_type.cc
@@ -176,7 +176,8 @@ PyObject* SortedDictType::repr(void)
  */
 int SortedDictType::contains(PyObject* key)
 {
-    if (this->key_type == nullptr || Py_IS_TYPE(key, this->key_type) == 0 || this->map->find(key) == this->map->end())
+    if (this->key_type == nullptr || Py_IS_TYPE(key, this->key_type) == 0 || !this->is_key_good(key)
+        || this->map->find(key) == this->map->end())
     {
         return 0;
     }

--- a/src/pysorteddict/sorted_dict_type.cc
+++ b/src/pysorteddict/sorted_dict_type.cc
@@ -41,7 +41,7 @@ void SortedDictType::deinit(void)
 /**
  * Check whether the given key can be inserted into this sorted dictionary. For
  * instance, NaN cannot be compared with other floating-point numbers, making
- * it an unsuitable key.
+ * it unsuitable for insertion.
  *
  * The caller should ensure that the key type is set and that it matches the
  * type of the given key prior to calling this method.

--- a/src/pysorteddict/sorted_dict_type.cc
+++ b/src/pysorteddict/sorted_dict_type.cc
@@ -50,8 +50,10 @@ void SortedDictType::deinit(void)
  *
  * @return `true` if the check succeeds, else `false`.
  */
-bool SortedDictType::is_key_good(PyObject* key){
-    if(this->key_type == &PyFloat_Type && std::isnan(PyFloat_AS_DOUBLE(key))){
+bool SortedDictType::is_key_good(PyObject* key)
+{
+    if (this->key_type == &PyFloat_Type && std::isnan(PyFloat_AS_DOUBLE(key)))
+    {
         return false;
     }
     return true;
@@ -115,7 +117,7 @@ bool SortedDictType::are_key_type_and_key_value_pair_good(PyObject* key, PyObjec
 
     // At this point, the key is guaranteed to be of the correct type. Hence,
     // it is safe to call this method.
-    if(!this->is_key_good(key)){
+    if (!this->is_key_good(key))
     {
         PyErr_Format(PyExc_ValueError, "bad key: %R", key);
         if (key_type_set_here)

--- a/src/pysorteddict/sorted_dict_type.cc
+++ b/src/pysorteddict/sorted_dict_type.cc
@@ -27,17 +27,6 @@ struct PyObject_Delete
 
 using PyObjectWrapper = std::unique_ptr<PyObject, PyObject_Delete>;
 
-void SortedDictType::deinit(void)
-{
-    for (auto& item : *this->map)
-    {
-        Py_DECREF(item.first);
-        Py_DECREF(item.second);
-    }
-    Py_XDECREF(this->key_type);
-    delete this->map;
-}
-
 /**
  * Check whether the given key can be inserted into this sorted dictionary. For
  * instance, NaN cannot be compared with other floating-point numbers, so it
@@ -135,6 +124,17 @@ bool SortedDictType::are_key_type_and_key_value_pair_good(PyObject* key, PyObjec
         Py_INCREF(this->key_type);
     }
     return true;
+}
+
+void SortedDictType::deinit(void)
+{
+    for (auto& item : *this->map)
+    {
+        Py_DECREF(item.first);
+        Py_DECREF(item.second);
+    }
+    Py_XDECREF(this->key_type);
+    delete this->map;
 }
 
 PyObject* SortedDictType::repr(void)

--- a/src/pysorteddict/sorted_dict_type.cc
+++ b/src/pysorteddict/sorted_dict_type.cc
@@ -65,7 +65,7 @@ bool SortedDictType::is_key_good(PyObject* key){
  *
  * @return `true` if the check succeeds, else `false`.
  */
-bool SortedDictType::are_key_type_and_key_value_pair_okay(PyObject* key, PyObject* value = nullptr)
+bool SortedDictType::are_key_type_and_key_value_pair_good(PyObject* key, PyObject* value = nullptr)
 {
     bool key_type_set_here = false;
     if (this->key_type == nullptr)
@@ -192,7 +192,7 @@ Py_ssize_t SortedDictType::len(void)
  */
 PyObject* SortedDictType::getitem(PyObject* key)
 {
-    if (!this->are_key_type_and_key_value_pair_okay(key))
+    if (!this->are_key_type_and_key_value_pair_good(key))
     {
         return nullptr;
     }
@@ -216,7 +216,7 @@ PyObject* SortedDictType::getitem(PyObject* key)
  */
 int SortedDictType::setitem(PyObject* key, PyObject* value)
 {
-    if (!this->are_key_type_and_key_value_pair_okay(key, value))
+    if (!this->are_key_type_and_key_value_pair_good(key, value))
     {
         return -1;
     }

--- a/src/pysorteddict/sorted_dict_type.hh
+++ b/src/pysorteddict/sorted_dict_type.hh
@@ -22,7 +22,7 @@ private:
     PyTypeObject* key_type;
 
 private:
-    bool is_key_good(PyObject* );
+    bool is_key_good(PyObject*);
     bool are_key_type_and_key_value_pair_good(PyObject*, PyObject*);
 
 public:

--- a/src/pysorteddict/sorted_dict_type.hh
+++ b/src/pysorteddict/sorted_dict_type.hh
@@ -22,7 +22,8 @@ private:
     PyTypeObject* key_type;
 
 private:
-    bool are_key_type_and_key_value_pair_okay(PyObject*, PyObject*);
+    bool is_key_good(PyObject* );
+    bool are_key_type_and_key_value_pair_good(PyObject*, PyObject*);
 
 public:
     void deinit(void);


### PR DESCRIPTION
Thereby allowing the check to be reused in other methods.

Closes #84.