### PR TITLE
Don't increase the reference count of the key type

### DIFF
--- a/src/pysorteddict/sorted_dict_module.cc
+++ b/src/pysorteddict/sorted_dict_module.cc
@@ -260,7 +260,7 @@ PyMODINIT_FUNC PyInit_pysorteddict(void)
     {
         return nullptr;
     }
-    if (PyModule_AddObjectRef(mod, "SortedDict", reinterpret_cast<PyObject*>(&sorted_dict_type)) < 0)
+    if (PyModule_AddObjectRef(mod, "SortedDict", reinterpret_cast<PyObject*>(&sorted_dict_type)) < 0)  // 🆕
     {
         Py_DECREF(mod);
         return nullptr;

--- a/src/pysorteddict/sorted_dict_module.cc
+++ b/src/pysorteddict/sorted_dict_module.cc
@@ -260,7 +260,7 @@ PyMODINIT_FUNC PyInit_pysorteddict(void)
     {
         return nullptr;
     }
-    if (PyModule_AddObjectRef(mod, "SortedDict", reinterpret_cast<PyObject*>(&sorted_dict_type)) < 0)  // 🆕
+    if (PyModule_AddObjectRef(mod, "SortedDict", reinterpret_cast<PyObject*>(&sorted_dict_type)) < 0)
     {
         Py_DECREF(mod);
         return nullptr;

--- a/src/pysorteddict/sorted_dict_type.cc
+++ b/src/pysorteddict/sorted_dict_type.cc
@@ -76,12 +76,12 @@ bool SortedDictType::is_key_good(PyObject* key)
     }
     if (this->key_type == PyDecimal_Type)
     {
-        PyObjectWrapper key_is_nan_callable(PyObject_GetAttrString(key, "is_nan"));  // 🆕
+        PyObjectWrapper key_is_nan_callable(PyObject_GetAttrString(key, "is_nan"));
         if (key_is_nan_callable == nullptr)
         {
             return false;
         }
-        PyObjectWrapper key_is_nan_result(PyObject_CallNoArgs(key_is_nan_callable.get()));  // 🆕
+        PyObjectWrapper key_is_nan_result(PyObject_CallNoArgs(key_is_nan_callable.get()));
         if (key_is_nan_result == nullptr)
         {
             return false;
@@ -293,7 +293,7 @@ int SortedDictType::setitem(PyObject* key, PyObject* value)
         // Insert a new key-value pair. The hint is correct; the key will get
         // inserted just before it.
         it = this->map->emplace_hint(it, key, value);
-        Py_INCREF(it->first);  // 🆕
+        Py_INCREF(it->first);
     }
     else
     {
@@ -301,7 +301,7 @@ int SortedDictType::setitem(PyObject* key, PyObject* value)
         Py_DECREF(it->second);
         it->second = value;
     }
-    Py_INCREF(it->second);  // 🆕
+    Py_INCREF(it->second);
     return 0;
 }
 
@@ -328,8 +328,8 @@ PyObject* SortedDictType::copy(void)
     this_copy->map = new std::map<PyObject*, PyObject*, SortedDictTypeKeyCompare>(*this->map);
     for (auto& item : *this_copy->map)
     {
-        Py_INCREF(item.first);  // 🆕
-        Py_INCREF(item.second);  // 🆕
+        Py_INCREF(item.first);
+        Py_INCREF(item.second);
     }
     this_copy->key_type = this->key_type;
     return sd_copy;
@@ -351,8 +351,8 @@ PyObject* SortedDictType::items(void)
             Py_DECREF(sd_items);
             return nullptr;
         }
-        PyTuple_SET_ITEM(sd_item, 0, Py_NewRef(item.first));  // 🆕
-        PyTuple_SET_ITEM(sd_item, 1, Py_NewRef(item.second));  // 🆕
+        PyTuple_SET_ITEM(sd_item, 0, Py_NewRef(item.first));
+        PyTuple_SET_ITEM(sd_item, 1, Py_NewRef(item.second));
         PyList_SET_ITEM(sd_items, idx++, sd_item);
     }
     return sd_items;
@@ -368,7 +368,7 @@ PyObject* SortedDictType::keys(void)
     Py_ssize_t idx = 0;
     for (auto& item : *this->map)
     {
-        PyList_SET_ITEM(sd_keys, idx++, Py_NewRef(item.first));  // 🆕
+        PyList_SET_ITEM(sd_keys, idx++, Py_NewRef(item.first));
     }
     return sd_keys;
 }
@@ -383,7 +383,7 @@ PyObject* SortedDictType::values(void)
     Py_ssize_t idx = 0;
     for (auto& item : *this->map)
     {
-        PyList_SET_ITEM(sd_values, idx++, Py_NewRef(item.second));  // 🆕
+        PyList_SET_ITEM(sd_values, idx++, Py_NewRef(item.second));
     }
     return sd_values;
 }

--- a/src/pysorteddict/sorted_dict_type.cc
+++ b/src/pysorteddict/sorted_dict_type.cc
@@ -76,12 +76,12 @@ bool SortedDictType::is_key_good(PyObject* key)
     }
     if (this->key_type == PyDecimal_Type)
     {
-        PyObjectWrapper key_is_nan_callable(PyObject_GetAttrString(key, "is_nan"));
+        PyObjectWrapper key_is_nan_callable(PyObject_GetAttrString(key, "is_nan"));  // 🆕
         if (key_is_nan_callable == nullptr)
         {
             return false;
         }
-        PyObjectWrapper key_is_nan_result(PyObject_CallNoArgs(key_is_nan_callable.get()));
+        PyObjectWrapper key_is_nan_result(PyObject_CallNoArgs(key_is_nan_callable.get()));  // 🆕
         if (key_is_nan_result == nullptr)
         {
             return false;
@@ -293,7 +293,7 @@ int SortedDictType::setitem(PyObject* key, PyObject* value)
         // Insert a new key-value pair. The hint is correct; the key will get
         // inserted just before it.
         it = this->map->emplace_hint(it, key, value);
-        Py_INCREF(it->first);
+        Py_INCREF(it->first);  // 🆕
     }
     else
     {
@@ -301,7 +301,7 @@ int SortedDictType::setitem(PyObject* key, PyObject* value)
         Py_DECREF(it->second);
         it->second = value;
     }
-    Py_INCREF(it->second);
+    Py_INCREF(it->second);  // 🆕
     return 0;
 }
 
@@ -328,8 +328,8 @@ PyObject* SortedDictType::copy(void)
     this_copy->map = new std::map<PyObject*, PyObject*, SortedDictTypeKeyCompare>(*this->map);
     for (auto& item : *this_copy->map)
     {
-        Py_INCREF(item.first);
-        Py_INCREF(item.second);
+        Py_INCREF(item.first);  // 🆕
+        Py_INCREF(item.second);  // 🆕
     }
     this_copy->key_type = this->key_type;
     return sd_copy;
@@ -351,8 +351,8 @@ PyObject* SortedDictType::items(void)
             Py_DECREF(sd_items);
             return nullptr;
         }
-        PyTuple_SET_ITEM(sd_item, 0, Py_NewRef(item.first));
-        PyTuple_SET_ITEM(sd_item, 1, Py_NewRef(item.second));
+        PyTuple_SET_ITEM(sd_item, 0, Py_NewRef(item.first));  // 🆕
+        PyTuple_SET_ITEM(sd_item, 1, Py_NewRef(item.second));  // 🆕
         PyList_SET_ITEM(sd_items, idx++, sd_item);
     }
     return sd_items;
@@ -368,7 +368,7 @@ PyObject* SortedDictType::keys(void)
     Py_ssize_t idx = 0;
     for (auto& item : *this->map)
     {
-        PyList_SET_ITEM(sd_keys, idx++, Py_NewRef(item.first));
+        PyList_SET_ITEM(sd_keys, idx++, Py_NewRef(item.first));  // 🆕
     }
     return sd_keys;
 }
@@ -383,7 +383,7 @@ PyObject* SortedDictType::values(void)
     Py_ssize_t idx = 0;
     for (auto& item : *this->map)
     {
-        PyList_SET_ITEM(sd_values, idx++, Py_NewRef(item.second));
+        PyList_SET_ITEM(sd_values, idx++, Py_NewRef(item.second));  // 🆕
     }
     return sd_values;
 }

--- a/src/pysorteddict/sorted_dict_type.cc
+++ b/src/pysorteddict/sorted_dict_type.cc
@@ -162,12 +162,6 @@ bool SortedDictType::are_key_type_and_key_value_pair_good(PyObject* key, PyObjec
         }
         return false;
     }
-
-    if (key_type_set_here)
-    {
-        // Increment the reference count, since this wasn't done above.
-        Py_INCREF(this->key_type);
-    }
     return true;
 }
 
@@ -178,7 +172,6 @@ void SortedDictType::deinit(void)
         Py_DECREF(item.first);
         Py_DECREF(item.second);
     }
-    Py_XDECREF(this->key_type);
     delete this->map;
 }
 
@@ -339,7 +332,6 @@ PyObject* SortedDictType::copy(void)
         Py_INCREF(item.second);
     }
     this_copy->key_type = this->key_type;
-    Py_XINCREF(this_copy->key_type);
     return sd_copy;
 }
 


### PR DESCRIPTION
It is just extra bookkeeping which serves no purpose.
* Built-in types are available as pointers to global objects. Hence they will naturally always be available.
* Imported types are made globally available once the first new reference is created, and their reference count is never decremented. Hence, they will also always be available.

Closes #105.