### PR TITLE
Raise the same exceptions in `__contains__` as in done in `__getitem__`

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -4,6 +4,7 @@
 
 <summary style="cursor: pointer">Looking for the documentation of an older version?</summary>
 
+▸ [0.5.3](https://github.com/tfpf/pysorteddict/blob/v0.5.3/docs/documentation.md)
 ▸ [0.5.2](https://github.com/tfpf/pysorteddict/blob/v0.5.2/docs/documentation.md)
 ▸ [0.5.1](https://github.com/tfpf/pysorteddict/blob/v0.5.1/docs/documentation.md)
 ▸ [0.5.0](https://github.com/tfpf/pysorteddict/blob/v0.5.0/docs/documentation.md)  
@@ -71,6 +72,55 @@ Return a human-readable representation of the sorted dictionary `d`.
 ### `key in d`
 
 Return whether `key` is present in the sorted dictionary `d`.
+
+#### Exceptions
+
+If no key-value pairs have been inserted into `d` yet, raise `RuntimeError`.
+
+```python
+from pysorteddict import *
+d = SortedDict()
+"foo" in d
+```
+
+```text
+Traceback (most recent call last):
+  File "…", line 3, in <module>
+    "foo" in d
+RuntimeError: key type not set: insert at least one item first
+```
+
+Otherwise, if `type(key)` does not match the type of the first key inserted into `d`, raise `TypeError`.
+
+```python
+from pysorteddict import *
+d = SortedDict()
+d["foo"] = ("bar", "baz")
+100 in d
+```
+
+```text
+Traceback (most recent call last):
+  File "…", line 4, in <module>
+    100 in d
+TypeError: got key 100 of type <class 'int'>, want key of type <class 'str'>
+```
+
+Otherwise, if `key` is not comparable with instances of its type, raise `ValueError`.
+
+```python
+from pysorteddict import *
+d = SortedDict()
+d[1.1] = ("racecar",)
+float("nan") in d
+```
+
+```text
+Traceback (most recent call last):
+  File "…", line 4, in <module>
+    float("nan") in d
+ValueError: got bad key nan of type <class 'float'>
+```
 
 ### `len(d)`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pysorteddict"
-version = "0.5.3"
+version = "0.6.0"
 authors = [
     {name = "Vishal Pankaj Chandratreya"},
 ]

--- a/src/pysorteddict/sorted_dict_type.cc
+++ b/src/pysorteddict/sorted_dict_type.cc
@@ -222,17 +222,15 @@ PyObject* SortedDictType::repr(void)
  *
  * @param ob Python object.
  *
- * @return 1 if it is present, else 0.
+ * @return -1 on error. 1 if it is present, else 0.
  */
 int SortedDictType::contains(PyObject* key)
 {
-    if (this->key_type == nullptr || Py_IS_TYPE(key, this->key_type) == 0 || !this->is_key_good(key)
-        || this->map->find(key) == this->map->end())
+    if (!this->are_key_type_and_key_value_pair_good(key))
     {
-        PyErr_Clear();
-        return 0;
+        return -1;
     }
-    return 1;
+    return this->map->find(key) == this->map->end() ? 0 : 1;
 }
 
 Py_ssize_t SortedDictType::len(void)

--- a/tests/test_fuzz.py
+++ b/tests/test_fuzz.py
@@ -76,18 +76,18 @@ class TestFuzz:
             key = self._gen(key_type)
             if self.is_sorted_dict_new:
                 with pytest.raises(RuntimeError, match="^key type not set: insert at least one item first$"):
-                    key in self.sorted_dict
+                    key in self.sorted_dict  # noqa: B015
                 continue
             if key_type is not self.key_type:
                 with pytest.raises(
                     TypeError,
                     match=re.escape(f"got key {key!r} of type {key_type!r}, want key of type {self.key_type!r}"),
                 ):
-                    key in self.sorted_dict
+                    key in self.sorted_dict  # noqa: B015
                 continue
             if (key_type is float or key_type is decimal.Decimal) and math.isnan(key):
                 with pytest.raises(ValueError, match=re.escape(f"got bad key {key!r} of type {key_type!r}")):
-                    key in self.sorted_dict
+                    key in self.sorted_dict  # noqa: B015
                 continue
             if self.normal_dict:
                 assert self._rg.choice([*self.normal_dict]) in self.sorted_dict


### PR DESCRIPTION
This brings the behaviour in line with that of `dict`.

Closes #117.