### PR TITLE
Reorganise common macros; opt out of Python limited API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,7 @@ cxx_standard_arg = "-std=c++14" if os.name != "nt" or sysconfig.get_platform().s
 setuptools.setup(
     ext_modules=[
         setuptools.Extension(
-            name="pysorteddict",
-            extra_compile_args=[cxx_standard_arg],
-            sources=glob.glob("src/pysorteddict/*.cc"),
-            py_limited_api=True,
+            name="pysorteddict", extra_compile_args=[cxx_standard_arg], sources=glob.glob("src/pysorteddict/*.cc")
         )
     ]
 )

--- a/src/pysorteddict/sorted_dict_type.cc
+++ b/src/pysorteddict/sorted_dict_type.cc
@@ -9,11 +9,6 @@
 #include "sorted_dict_type.hh"
 #include "sorted_dict_utils.hh"
 
-#define LEFT_PARENTHESIS "\u0028"
-#define RIGHT_PARENTHESIS "\u0029"
-#define LEFT_CURLY_BRACKET "\u007B"
-#define RIGHT_CURLY_BRACKET "\u007D"
-
 /**
  * Import a Python type.
  *

--- a/src/pysorteddict/sorted_dict_utils.hh
+++ b/src/pysorteddict/sorted_dict_utils.hh
@@ -5,6 +5,11 @@
 #include <Python.h>
 #include <memory>
 
+#define LEFT_PARENTHESIS "\u0028"
+#define RIGHT_PARENTHESIS "\u0029"
+#define LEFT_CURLY_BRACKET "\u007B"
+#define RIGHT_CURLY_BRACKET "\u007D"
+
 /**
  * C++-style clean-up implementation for Python objects.
  */


### PR DESCRIPTION
The `py_limited_api` argument in `setup.py` does nothing.
  * To opt in to use the limited API, the macro `Py_LIMITED_API` has to be defined before including the Python development header file.
  * Macros such as `PyTuple_SET_ITEM` are then unavailable, and the project build fails.
  * Hence, I must opt out of it (which I already have; Setuptools is doing the wrong thing here).

I like using macros for curly and other brackets because they don't mess with the scope highlighting feature of VIM.
* Those macros (and the smart pointer which can manage Python objects) will be required in the `__repr__` method of `SortedDictKeysType`. (See #120.)
* Hence, move them to the utilities file.