### PR TITLE
Pre-requisites for adding changelog; minor fixes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,8 +10,6 @@ extensions = ["myst_parser"]
 source_suffix = [".md", ".rst"]
 exclude_patterns = ["_build"]
 
-myst_heading_anchors = 3
-
 html_css_files = ["custom.css"]
 html_logo = "logo.svg"
 html_static_path = ["_static"]
@@ -23,3 +21,5 @@ html_theme_options = {
 }
 html_title = project
 html_use_index = False
+
+myst_heading_anchors = 3

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,8 +8,9 @@ author = "Vishal Pankaj Chandratreya"
 
 extensions = ["myst_parser"]
 source_suffix = [".md", ".rst"]
-
 exclude_patterns = ["_build"]
+
+myst_heading_anchors = 3
 
 html_css_files = ["custom.css"]
 html_logo = "logo.svg"

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -525,7 +525,7 @@ print(d)
 SortedDict({'a_bar': 'eggs', 'a_baz': 'eggs', 'bar': 'spam', 'baz': 'spam'})
 ```
 
-Some modifications are disallowed, however. See [`del d[key]`](#del-dkey) and [`d.clear()`](dclear).
+Some modifications are disallowed, however. See [`del d[key]`](#del-dkey) and [`d.clear()`](#dclear).
 
 </details>
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -2,7 +2,7 @@
 
 <details class="notice">
 
-<summary>Looking for the documentation of an older version?</summary>
+<summary>Documentation of older versions is available on GitHub.</summary>
 
 ▸ [0.7.0](https://github.com/tfpf/pysorteddict/blob/v0.7.0/docs/documentation.md)  
 ▸ [0.6.0](https://github.com/tfpf/pysorteddict/blob/v0.6.0/docs/documentation.md)  
@@ -525,7 +525,7 @@ print(d)
 SortedDict({'a_bar': 'eggs', 'a_baz': 'eggs', 'bar': 'spam', 'baz': 'spam'})
 ```
 
-Some modifications are disallowed, however. See [`del d[key]`](#del-d-key) and [`d.clear()`](d-clear).
+Some modifications are disallowed, however. See [`del d[key]`](#del-dkey) and [`d.clear()`](dclear).
 
 </details>
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@ ascending order.
 pysorteddict is implemented entirely in C++. ``SortedDict`` provides a Python interface to ``std::map``.
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    installation
    usage


### PR DESCRIPTION
The changelog will contain a number of headings. Exclude headings altogether from the TOC.

Fix the cross-reference to `del d[key]` and `d.clear()` in the documentation. They work as they are by pure coincidence: the cross-references I have used happen to match the generated HTML IDs. Can't rely on this behaviour, so use the MyST feature instead.