### PR TITLE
Use Git LFS for all binary files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-docs/_static/fonts.zip diff=lfs filter=lfs merge=lfs -text


### PR DESCRIPTION
I was using it for only fonts, but since I'll now add graphs to show the performance benchmarks, I should track images also using Git LFS.