### PR TITLE
Try to use C++ `new` and `delete` instead of custom allocators and deallocators (failed)

### DIFF
--- a/src/pysorteddict/sorted_dict_module.cc
+++ b/src/pysorteddict/sorted_dict_module.cc
@@ -131,9 +131,7 @@ static void sorted_dict_type_dealloc(PyObject* self)
     // but it looks like the deinitialisation (finalisation) function is not
     // automatically called prior to deallocation. Further, the documentation
     // recommends doing both here.
-    SortedDictType* sd = reinterpret_cast<SortedDictType*>(self);
-    sd->deinit();
-    Py_TYPE(self)->tp_free(self);
+    delete self;
 }
 
 /**
@@ -328,7 +326,7 @@ static int sorted_dict_type_init(PyObject* self, PyObject* args, PyObject* kwarg
  */
 static PyObject* sorted_dict_type_new(PyTypeObject* type, PyObject* args, PyObject* kwargs)
 {
-    return SortedDictType::New(type, args, kwargs);
+    return reinterpret_cast<PyObject*>( new SortedDictType(args, kwargs));
 }
 
 static PyTypeObject sorted_dict_type = {
@@ -349,9 +347,7 @@ static PyTypeObject sorted_dict_type = {
     .tp_methods = sorted_dict_type_methods,
     .tp_getset = sorted_dict_type_getset,
     .tp_init = sorted_dict_type_init,
-    .tp_alloc = PyType_GenericAlloc,
     .tp_new = sorted_dict_type_new,
-    .tp_free = PyObject_Free,
 };
 
 static PyModuleDef sorted_dict_module = {

--- a/src/pysorteddict/sorted_dict_type.cc
+++ b/src/pysorteddict/sorted_dict_type.cc
@@ -2,6 +2,7 @@
 #include <Python.h>
 #include <cmath>
 #include <map>
+#include <cstddef>
 #include <string>
 #include <utility>
 
@@ -473,14 +474,14 @@ int SortedDictType::init(PyObject* args, PyObject* kwargs)
     return 0;
 }
 
-PyObject* SortedDictType::New(PyTypeObject* type, PyObject* args, PyObject* kwargs)
+void*SortedDictType::operator new(std::size_t count) noexcept
 {
     if (!import_supported_key_types())
     {
         return nullptr;
     }
 
-    PyObject* self = type->tp_alloc(type, 0);  // 🆕
+    void* self = PyType_GenericAlloc(type, 0);  // 🆕
     if (self == nullptr)
     {
         return nullptr;
@@ -489,9 +490,12 @@ PyObject* SortedDictType::New(PyTypeObject* type, PyObject* args, PyObject* kwar
     // Python's default allocator claims to initialise the contents of the
     // allocated memory to null, but actually writes zeros to it. Hence,
     // explicitly initialise them.
-    SortedDictType* sd = reinterpret_cast<SortedDictType*>(self);
+    SortedDictType* sd = static_cast<SortedDictType*>(self);
     sd->map = new std::map<PyObject*, SortedDictValue, SortedDictKeyCompare>;
     sd->key_type = nullptr;
     sd->known_referrers = 0;
     return self;
+}
+
+SortedDictType::SortedDictType(PyObject*args,PyObject*kwargs){
 }

--- a/src/pysorteddict/sorted_dict_type.hh
+++ b/src/pysorteddict/sorted_dict_type.hh
@@ -3,6 +3,7 @@
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
+#include <cstddef>
 #include <map>
 
 /**
@@ -78,7 +79,8 @@ public:
     PyObject* values(void);
     PyObject* get_key_type(void);
     int init(PyObject*, PyObject*);
-    static PyObject* New(PyTypeObject*, PyObject*, PyObject*);
+    static void* operator new(std::size_t) noexcept;
+    SortedDictType(PyObject*,PyObject*);
 
     friend struct SortedDictKeysType;
     friend struct SortedDictViewIterType;


### PR DESCRIPTION
This pull request serves to document why I am using a custom `New` function to allocate and initialise Python objects instead of using `new`.