### PR TITLE
Move homepage build dependencies to `pyproject.toml`

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,6 +32,7 @@ jobs:
       - run: unzip assets.zip
         working-directory: docs/_static/
       - uses: actions/setup-python@v5
+      - run: pip install -U pip
       - run: pip install --group docs
       - run: sphinx-build . _build/
         working-directory: docs/

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,8 @@ jobs:
       - run: unzip assets.zip
         working-directory: docs/_static/
       - uses: actions/setup-python@v5
-      - run: pip install -r requirements.txt && sphinx-build . _build
+      - run: pip install --group docs
+      - run: sphinx-build . _build/
         working-directory: docs/
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,0 @@
-furo~=2024.8
-myst-parser~=4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,9 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[dependency-groups]
+docs = ["furo~=2024.8", "myst-parser~=4.0"]
+
 [project]
 name = "pysorteddict"
 version = "0.11.0"
@@ -72,7 +75,7 @@ detached = true
 # Building the documentation does not require installing this project, but does
 # require some dependencies. I can't figure out a way to get Hatch to only
 # install those dependencies without repeating them here. Hence, install them
-# in this environment manually from the requirements file. Otherwise, the below
+# in this environment manually from the dependency group. Otherwise, the below
 # command will fail.
 docs = "sphinx-build docs/ docs/_build/"
 


### PR DESCRIPTION
* [PEP 735 – Dependency Groups in pyproject.toml](https://peps.python.org/pep-0735/)
* [Dependency Groups - Python Packaging User Guide](https://packaging.python.org/en/latest/specifications/dependency-groups/)