### PR TITLE
Use pi symbol in homepage

### DIFF
--- a/docs/_static/assets.zip
+++ b/docs/_static/assets.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:41974f29f3c1433270abc1cc49005f05b4992b59b77dfb2857fa078889a21e1a
-size 523209
+oid sha256:712e1799a687e0a5b008ffc233f289f108fe492b8ebb79f4d37baa91ea207845
+size 523010

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ html_static_path = ["_static"]
 html_theme = "furo"
 html_theme_options = {
     "light_css_variables": {
-        "font-stack": "Signika pysorteddict, Cochineal, Arial, system-ui, sans-serif, Apple Color Emoji, Segoe UI Emoji",
+        "font-stack": "Signika pysorteddict, system-ui, sans-serif, Apple Color Emoji, Segoe UI Emoji",
         "font-stack--headings": "Signika pysorteddict, system-ui, sans-serif, Apple Color Emoji, Segoe UI Emoji",
         "font-stack--monospace": "JetBrainsMono pysorteddict, Consolas, Monaco, Liberation Mono, monospace",
     },

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ html_static_path = ["_static"]
 html_theme = "furo"
 html_theme_options = {
     "light_css_variables": {
-        "font-stack": "Signika pysorteddict, system-ui, sans-serif, Apple Color Emoji, Segoe UI Emoji",
+        "font-stack": "Signika pysorteddict, Cochineal, Arial, system-ui, sans-serif, Apple Color Emoji, Segoe UI Emoji",
         "font-stack--headings": "Signika pysorteddict, system-ui, sans-serif, Apple Color Emoji, Segoe UI Emoji",
         "font-stack--monospace": "JetBrainsMono pysorteddict, Consolas, Monaco, Liberation Mono, monospace",
     },

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -16,7 +16,7 @@ The table below describes the environment the performance benchmarks were run in
 The key type chosen was `float`, since it is easy to generate floating-point numbers uniformly distributed in the unit
 interval. Comparing two `float`s is straightforward (as opposed to comparing, say, two `str`s—if their lengths are
 different, they may introduce noise in the benchmarks). Before every benchmark, the random number generator was seeded
-with pi, a nothing-up-my-sleeve number.
+with _π_, a nothing-up-my-sleeve number.
 
 There is an extra step required when using `float` keys: the check for NaN. Hence, the performance will be marginally
 worse than if `int` keys were used.


### PR DESCRIPTION
Downloaded the files for the bold and regular styles of Siginka with all available character sets. Picked out the the glyphs for pi from them and put them into the files checked into this repository.