### PR TITLE
Upgrade macOS and Windows runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     needs: [style]
     strategy:
       matrix:
-        os: ['macos-13', 'macos-14', 'ubuntu-24.04', 'windows-2022']
+        os: ['macos-14', 'macos-15-intel', 'ubuntu-24.04', 'windows-2025']
     name: build on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
The macOS 13 AMD64 image is deprecated. Also, a new Windows runner image is available.