### PR TITLE
Add pytest configuration for parallel execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - run: |
-          pip install -v .[cov]
-          pytest -n logical
+          pip install -v .[cov] && pytest
           gcovr --json-summary-pretty | tee coverage.json
           [ $(jq '.line_percent*10' coverage.json) -ge 950 ]
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ Changelog = "https://tfpf.github.io/pysorteddict/changelog.html"
 archs = ["auto64"]
 build-verbosity = 1
 enable = ["pypy"]
-test-command = "pytest -n logical {package}"
+test-command = "pytest {package}"
 test-requires = ["pytest-xdist"]
 
 [tool.hatch.envs.default]
@@ -64,7 +64,7 @@ CFLAGS = "--coverage"
 
 [tool.hatch.envs.cov.scripts]
 cov = [
-    "rm -fr build/ cov/ && pip install . && pytest -n logical",
+    "rm -fr build/ cov/ && pip install . && pytest",
     "mkdir -p cov/ && gcovr --html-details cov/index.html",
 ]
 
@@ -78,6 +78,9 @@ detached = true
 # in this environment manually from the dependency group. Otherwise, the below
 # command will fail.
 docs = "sphinx-build docs/ docs/_build/"
+
+[tool.pytest.ini_options]
+addopts = "--dist=worksteal -n logical"
 
 [tool.ruff]
 line-length = 119


### PR DESCRIPTION
Without this, pytest runs the slowest tests serially even when multiple workers are available. I checked Xfce Task Manager.