### PR TITLE
Do not raise error when `decimal.Decimal` import fails

### DIFF
--- a/src/pysorteddict/sorted_dict_module.cc
+++ b/src/pysorteddict/sorted_dict_module.cc
@@ -826,5 +826,6 @@ PyMODINIT_FUNC PyInit_pysorteddict(void)
         Py_DECREF(mod);
         return nullptr;
     }
+    import_supported_key_types();
     return mod;
 }

--- a/src/pysorteddict/sorted_dict_type.cc
+++ b/src/pysorteddict/sorted_dict_type.cc
@@ -45,7 +45,16 @@ static PyTypeObject* import_python_type(char const* module_name, char const* typ
 }
 
 // Key types which have to be imported explicitly using the above function.
-static PyTypeObject* PyDecimal_Type = import_python_type("decimal", "Decimal");
+static PyTypeObject* PyDecimal_Type;
+
+/**
+ * Import all supported key types from Python which are not built-in. Make them
+ * available globally so that their reference counts need not be managed.
+ */
+void import_supported_key_types(void)
+{
+    PyDecimal_Type = import_python_type("decimal", "Decimal");
+}
 
 /**
  * Check whether the given key can be inserted into this sorted dictionary. For

--- a/src/pysorteddict/sorted_dict_type.hh
+++ b/src/pysorteddict/sorted_dict_type.hh
@@ -5,6 +5,8 @@
 #include <Python.h>
 #include <map>
 
+void import_supported_key_types(void);
+
 /**
  * C++-style comparison implementation for Python objects.
  */


### PR DESCRIPTION
Just make `decimal.Decimal` an unsupported key type if that happens.