### PR TITLE
Switch to multi-phase initialisation

### DIFF
--- a/src/pysorteddict/sorted_dict_module.cc
+++ b/src/pysorteddict/sorted_dict_module.cc
@@ -817,8 +817,13 @@ static int sorted_dict_module_exec(PyObject* mod)
 }
 
 static PyModuleDef_Slot sorted_dict_module_slots[] = {
-    { Py_mod_exec, sorted_dict_module_exec },
+    { Py_mod_exec, reinterpret_cast<void*>(sorted_dict_module_exec) },
+#if PY_VERSION_HEX >= 0x030C0000
     { Py_mod_multiple_interpreters, Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED },
+#endif
+#if PY_VERSION_HEX >= 0x030D0000
+    { Py_mod_gil, Py_MOD_GIL_USED },
+#endif
     { 0, nullptr },
 };
 


### PR DESCRIPTION
[Defining extension modules &#8212; Python 3.14.0 documentation](https://docs.python.org/3/c-api/extension-modules.html#legacy-single-phase-initialization)

> **Attention:** Single-phase initialization is a legacy mechanism to initialize extension modules, with known drawbacks and design flaws. Extension module authors are encouraged to use multi-phase initialization instead.