### PR TITLE
Support the free-threaded build of Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           gcovr --json-summary-pretty | tee coverage.json
           [ $(jq '.line_percent*10' coverage.json) -ge 950 ]
         env:
-          CFLAGS: --coverage
+          CXXFLAGS: --coverage
       - uses: stellarhub/push-gist-action@v1
         with:
           token: ${{ secrets.PAT }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ detached = true
 features = ["cov"]
 
 [tool.hatch.envs.cov.env-vars]
-CFLAGS = "--coverage"
+CXXFLAGS = "--coverage"
 
 [tool.hatch.envs.cov.scripts]
 cov = [


### PR DESCRIPTION
Impeded because of what looks like a cibuildwheel bug.

> LINK : fatal error LNK1104: cannot open file 'python314.lib'
> error: command 'C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.44.35207\\bin\\HostX86\\x64\\link.exe' failed with exit code 1104
