### PR TITLE
Build free-threaded wheels but not on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pypa/cibuildwheel@v3.2.0
+      - uses: pypa/cibuildwheel@v3.3.0
         with:
           output-dir: wheelhouse
       - uses: actions/upload-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ Changelog = "https://tfpf.github.io/pysorteddict/changelog.html"
 [tool.cibuildwheel]
 archs = ["auto64"]
 build-verbosity = 1
-enable = ["pypy"]
+enable = ["pypy", "pypy-eol"]
 skip = ["cp3??t-win*"]
 test-command = "pytest {package}"
 test-requires = ["pytest-xdist"]


### PR DESCRIPTION
Because of a cibuildwheel bug, a free-threaded build wheel cannot be built for Windows. See #234.