### PR TITLE
Rewrite changelog to adhere to 'Keep a Changelog'

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.13.0](https://github.com/tfpf/pysorteddict/compare/v0.12.1...v0.13.0)
+## [0.13.0](https://github.com/tfpf/pysorteddict/compare/v0.12.1...v0.13.0) (2025-12-23)
 
 ### Added
 


### PR DESCRIPTION
[Keep a Changelog](https://keepachangelog.com/en/1.1.0/)

See issue 204 in https://github.com/olivierlacan/keep-a-changelog.

> Currently the version heading is
> ### 1.1.1 - 01-01-1970
> 
> According to  issue 59 the statistics about dates are:
> 
> * 90% of repo (try too look most starred repo in github) prints in format tag (date)
> 
> * 5% prints in the same format, like yours tag - date
> 
> * 5% don't print date at all