### PR TITLE
Teal text selection colour in website

### DIFF
--- a/docs/_static/styles/custom.css
+++ b/docs/_static/styles/custom.css
@@ -40,6 +40,10 @@
   src: url(../fonts/Signika/Signika-Bold.woff2);
 }
 
+::selection {
+  background: rgba(39, 180, 166, 0.4);
+}
+
 summary {
   color: var(--color-link);
   cursor: pointer;
@@ -47,10 +51,6 @@ summary {
 
 summary:hover {
   text-decoration: underline;
-}
-
-::selection {
-  background: rgba(39, 180, 166, 0.4);
 }
 
 .notice {


### PR DESCRIPTION
Goes nicely with the teal theme I have used throughout.

# Chromium

![chromium](https://github.com/user-attachments/assets/c33d78f9-6a08-40dd-b192-bb8d54cfdf9d)

# Edge

![edge](https://github.com/user-attachments/assets/e6f5e11b-916f-4f37-b965-3a43609337b7)

# Firefox

![firefox](https://github.com/user-attachments/assets/167c1c50-80b4-4f72-8dc6-b0a7d8d25ab5)

# IceCat

![icecat](https://github.com/user-attachments/assets/3800c56f-644c-480a-9808-fa646576c2f8)

# Opera

![opera](https://github.com/user-attachments/assets/118d909f-d038-43d5-bf50-58a53f1e345b)
