### PR TITLE
Simplify Python calls from C++

### DIFF
--- a/src/pysorteddict/sorted_dict_type.cc
+++ b/src/pysorteddict/sorted_dict_type.cc
@@ -83,17 +83,12 @@ bool SortedDictType::is_key_good(PyObject* key)
     if (this->key_type == PyDecimal_Type)
     {
         PyErrorClearer _;
-        PyObjectWrapper key_is_nan_callable(PyObject_GetAttrString(key, "is_nan"));  // 🆕
-        if (key_is_nan_callable == nullptr)
+        PyObjectWrapper key_is_nan(PyObject_CallMethod(key, "is_nan", nullptr));  // 🆕
+        if (key_is_nan == nullptr)
         {
             return false;
         }
-        PyObjectWrapper key_is_nan_result(PyObject_CallNoArgs(key_is_nan_callable.get()));  // 🆕
-        if (key_is_nan_result == nullptr)
-        {
-            return false;
-        }
-        return PyObject_IsTrue(key_is_nan_result.get()) == 0;
+        return Py_IsFalse(key_is_nan.get());
     }
     return true;
 }


### PR DESCRIPTION
Creating `decimal.py` with the below code causes the standard library module `decimal` to be passed over for this file.

```python
import math


def is_nan(self):
    return math.isnan(self)


Decimal = type("Decimal", (float,), {"is_nan": is_nan})
```

When the `is_nan` method is removed or if it is updated to raise an exception, `SortedDict` rejects the key.

```python
In [1]: from pysorteddict import SortedDict

In [2]: d = SortedDict()

In [3]: d[Decimal(0)] = 0
───────────────────────────────────────────────────────────────────────────
ValueError                                Traceback (most recent call last)
Cell In[3], line 1
────▶ 1 d[Decimal(0)] = 0

ValueError: got bad key 0.0 of type <class 'decimal.Decimal'>
```

Otherwise, everything works, as it should.