### PR TITLE
Use `Py_Is` instead of `Py_IsFalse`, which is not available in PyPy

### DIFF
--- a/src/pysorteddict/sorted_dict_type.cc
+++ b/src/pysorteddict/sorted_dict_type.cc
@@ -89,6 +89,7 @@ bool SortedDictType::is_key_good(PyObject* key)
             return false;
         }
         return Py_IsFalse(key_is_nan.get());
+        // return Py_Is(key_is_nan.get(), Py_False);
     }
     return true;
 }

--- a/src/pysorteddict/sorted_dict_type.cc
+++ b/src/pysorteddict/sorted_dict_type.cc
@@ -88,8 +88,7 @@ bool SortedDictType::is_key_good(PyObject* key)
         {
             return false;
         }
-        return Py_IsFalse(key_is_nan.get());
-        // return Py_Is(key_is_nan.get(), Py_False);
+        return Py_Is(key_is_nan.get(), Py_False);
     }
     return true;
 }


### PR DESCRIPTION
Compilation would have failed if I had run the CI pipeline, but I didn't because I was confident when I merged #272.😅