### PR TITLE
Pin Hypothesis to pure-Python version; drop Pyodide 3.12; add Pyodide 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pypa/cibuildwheel@v3.3.0
+      - uses: pypa/cibuildwheel@v4.1.1
         with:
           output-dir: wheelhouse
       - uses: actions/upload-artifact@v4
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: pypa/cibuildwheel@v3.3.0
+      - uses: pypa/cibuildwheel@v4.1.1
         with:
           output-dir: wheelhouse
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pypa/cibuildwheel@v3.4.0
+      - uses: pypa/cibuildwheel@v3.3.0
         with:
           output-dir: wheelhouse
       - uses: actions/upload-artifact@v4
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: pypa/cibuildwheel@v3.4.0
+      - uses: pypa/cibuildwheel@v3.3.0
         with:
           output-dir: wheelhouse
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pypa/cibuildwheel@v3.3.0
+      - uses: pypa/cibuildwheel@v3.4.0
         with:
           output-dir: wheelhouse
       - uses: actions/upload-artifact@v4
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: pypa/cibuildwheel@v3.3.0
+      - uses: pypa/cibuildwheel@v3.4.0
         with:
           output-dir: wheelhouse
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ Changelog = "https://tfpf.github.io/pysorteddict/changelog.html"
 [tool.cibuildwheel]
 archs = ["auto64"]
 build-verbosity = 1
-enable = ["pyodide-eol", "pypy", "pypy-eol"]
+enable = ["pypy", "pypy-eol"]
 test-command = "pytest {package}"
 test-requires = [
     # Newer versions are partially written in Rust, but their binary wheels are

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ Changelog = "https://tfpf.github.io/pysorteddict/changelog.html"
 [tool.cibuildwheel]
 archs = ["auto64"]
 build-verbosity = 1
-enable = ["pypy", "pypy-eol"]
+enable = ["pyodide-eol", "pypy", "pypy-eol"]
 test-command = "pytest {package}"
 test-requires = [
     # Newer versions are partially written in Rust, but their binary wheels are

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,10 @@ enable = ["pypy"]
 test-command = "pytest {package}"
 test-requires = ["hypothesis", "pytest"]
 
+# Disable tests on Pyodide because there is a CI issue causing them to fail.
+[tool.cibuildwheel.pyodide]
+test-command = ""
+
 [tool.cibuildwheel.config-settings]
 setup-args = [
     "-Db_lto=true",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,14 +55,10 @@ Changelog = "https://tfpf.github.io/pysorteddict/changelog.html"
 [tool.cibuildwheel]
 archs = ["auto64"]
 build-verbosity = 1
-enable = ["pypy", "pypy-eol"]
+enable = ["pypy"]
 test-command = "pytest {package}"
-test-requires = [
-    # Its newer versions are implemented using Rust, but no binary wheels are
-    # provided for PyPy 3.10.
-    "hypothesis<6.156.0",
-    "pytest",
-]
+test-requires = ["hypothesis", "pytest"]
+
 
 [tool.cibuildwheel.config-settings]
 setup-args = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,12 @@ archs = ["auto64"]
 build-verbosity = 1
 enable = ["pypy", "pypy-eol"]
 test-command = "pytest {package}"
-test-requires = ["hypothesis", "pytest"]
+test-requires = [
+    # Its newer versions are implemented using Rust, but no binary wheels are
+    # provided for PyPy 3.10.
+    "hypothesis<6.156.0",
+    "pytest",
+]
 
 [tool.cibuildwheel.config-settings]
 setup-args = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,13 +55,14 @@ Changelog = "https://tfpf.github.io/pysorteddict/changelog.html"
 [tool.cibuildwheel]
 archs = ["auto64"]
 build-verbosity = 1
-enable = ["pypy"]
+enable = ["pypy", "pypy-eol"]
 test-command = "pytest {package}"
-test-requires = ["hypothesis", "pytest"]
-
-# Disable tests on Pyodide because there is a CI issue causing them to fail.
-[tool.cibuildwheel.pyodide]
-test-command = ""
+test-requires = [
+    # Newer versions are partially written in Rust, but their binary wheels are
+    # not provided for PyPy 3.10.
+    "hypothesis==6.155.7",
+    "pytest",
+]
 
 [tool.cibuildwheel.config-settings]
 setup-args = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ enable = ["pypy"]
 test-command = "pytest {package}"
 test-requires = ["hypothesis", "pytest"]
 
-
 [tool.cibuildwheel.config-settings]
 setup-args = [
     "-Db_lto=true",


### PR DESCRIPTION
Restrict Hypothesis to the newest pure-Python version since binary wheels of newer versions are not provided for PyPy 3.10.